### PR TITLE
Fixed Naples being stuck in mission tree

### DIFF
--- a/AN_Core/missions/EMP_Neapolitan_Missions.txt
+++ b/AN_Core/missions/EMP_Neapolitan_Missions.txt
@@ -646,8 +646,16 @@ emp_naples_5 = {
 		}
 		trigger = {
 			121 = {
-				has_building = town
-				has_building = artisanate
+				OR = {
+					has_building = town
+					has_building = city
+					has_building = metropolis
+				}
+				OR = {
+					has_building = artisanate
+					has_building = theatre
+					has_building = museum
+				}
 			}
 			has_institution = renaissance
 		}


### PR DESCRIPTION
Fixed Naples upgrading too fast to a city and not having Renaissance and then being stuck in this mission.
![Screenshot_20241014_104640](https://github.com/user-attachments/assets/8574e147-bc2b-466d-ab6b-ee6405bde25c)
